### PR TITLE
Edit Toptal Title on Freelance Job Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Tech-Jobs/blob
 - [Monster](http://monster.com/)
 - [Flex Jobs](http://flexjobs.com/jobs)
 - [Ladders](https://www.theladders.com)
-- [Toptotal](https://www.toptal.com)
+- [Toptal](https://www.toptal.com)
 - [Guru](https://guru.com)
 - [Freelancermap](https://freelancermap.com)
 


### PR DESCRIPTION
It should be [Toptal] because it is a combination of the two words “Top” and “Talent.” 

**Source:** [Toptal FAQ](https://www.toptal.com/freelance-jobs/faq#:~:text=The%20name%20%E2%80%9CToptal''%20comes,paid%20on%20time%2C%20every%20time.)
