### PR TITLE
fix or remove broken job site links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Tech-Jobs/blob
 
 ## Famous Job Sites
 - [Linkedin](http://linkedIn.com)
-- [StackOverflow](http://stackoverflow.com/jobs)
-- [Github](http://jobs.github.com)
+- [StackOverflow](https://stackoverflow.co/company/careers/)
 - [Glassdoor](https://www.glassdoor.co.in)
 - [Upwork](https://upwork.com)
 - [Naukri](https://www.naukri.com)
@@ -37,10 +36,9 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Tech-Jobs/blob
 - [Scalable Path](https://www.scalablepath.com/)
 - [Freshersworld](https://www.Freshersworld.com/)
 - [JobsforHer](https://www.JobsforHer.com/)
-- [CutShort](https://www.CutShort.com/)
+- [CutShort](https://cutshort.io/)
 - [Jobsora](https://www.jobsora.com/)
 - [Hirist](https://www.Hirist.com/)
-- [Snaphunt](https://www.Snaphunt.com/)
 - [Cuvette](https://cuvette.tech/)
 - [Unstop](https://unstop.com/)
 - [Hired](https://hired.com/)


### PR DESCRIPTION
Several links in README.md were outdated or broken.   This commit updates or removes them to keep the list relevant and functional.

Changes:
- Removed StackOverflow Jobs (service discontinued).
- Removed GitHub Jobs (service discontinued).
- Fixed CutShort link (changed from cutshort.com → cutshort.io).
- Removed Snaphunt (service discontinued).

This improves documentation accuracy and prevents users from landing on dead pages.