### PR TITLE
docs: add Canada early-career tech jobs board

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Contributors: Thanks to everyone who has added resources and improved this list.
 - [Status / Last updated](#status--last-updated)
 - [Famous Job Sites](#Famous-Job-Sites)
 - [Remote Job Sites](#Remote-Job-Sites)
+- [Internship and Early Career Job Sites](#internship-and-early-career-job-sites)
 - [Freelance Job Sites](#Freelance-Job-Sites)
 - [Python Job Sites](#Python-Job-Sites)
 - [Html and Css Job Sites](#Html-and-Css-Job-Sites)
@@ -122,6 +123,10 @@ Contributors: Thanks to everyone who has added resources and improved this list.
 - [Benture](https://benture.io)
 - [Remote.co](https://remote.co/)
 - [Remotive](https://remotive.com)
+
+## Internship and Early Career Job Sites
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/categories/software-engineering/) — Canada-focused student and recent-grad tech roles, including internships, co-ops, new-grad, junior, software engineering, and data/ML jobs.
 
 ## Freelance Job Sites
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the job-board resource list under a new internship/early-career section.
- Uses the Canada tech/software deep link for students and recent grads looking for internships, co-ops, new-grad, junior, software engineering, and data/ML roles.

## Fit
Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board. It is relevant to this list because it covers tech roles and early-career opportunities rather than one-off postings.

## Test plan
- Markdown-only change; no build required.
- Checked the repository for an existing Hanzilla link before opening this PR.
