### PR TITLE
Add Hanzilla Jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Contributors: Thanks to everyone who has added resources and improved this list.
 - [Freshersworld](https://www.freshersworld.com/)
 - [Github](http://jobs.github.com)
 - [Glassdoor](https://www.glassdoor.co.in)
-- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) — Daily-updated Canadian student and recent-grad tech internships, co-ops, new-grad, and junior roles.
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)
 - [Hired](https://hired.com/)
 - [Hirist](https://www.hirist.com/)
 - [JobsforHer](https://www.jobsforher.com/)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Contributors: Thanks to everyone who has added resources and improved this list.
 - [Freshersworld](https://www.freshersworld.com/)
 - [Github](http://jobs.github.com)
 - [Glassdoor](https://www.glassdoor.co.in)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) — Daily-updated Canadian student and recent-grad tech internships, co-ops, new-grad, and junior roles.
 - [Hired](https://hired.com/)
 - [Hirist](https://www.hirist.com/)
 - [JobsforHer](https://www.jobsforher.com/)


### PR DESCRIPTION
## Summary

Adds Hanzilla Jobs to the job board list as a Canada-focused resource for students and early-career tech candidates.

Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad board covering internships, co-ops, new-grad, and junior roles.

## Verification

- Checked for an existing Hanzilla entry in the README before editing.
- Ran `git diff --check`.
