### PR TITLE
Add Jobs in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Contributors: Thanks to everyone who has added resources and improved this list.
 - [JavaScript_Job](https://javascriptjob.xyz)
 - [Vue Jobs](https://vuejobs.com)
 - [React Jobs](https://reactjobsboard.com)
+- [Jobs in JS](https://jobsinjs.com)
 
 ## Mobile App Development Job Sites
 


### PR DESCRIPTION
Adding https://jobsinjs.com to the Javascript Job Site section.

Jobs in JS is a niche job board for Javascript devs.